### PR TITLE
better way for handling suscribtion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+package-lock.json
 
 node_modules
 dist


### PR DESCRIPTION
in the previos solution you didn't use the compute value directly as the subscribe function, to be able to track if there are no changes, but actualy its never tracking it, because the old value is getting staled, plus the current code is realy growing your subscribtion exponentialy because the atom is new to him every time so he is adding him anyway.

in my solution you just unsubscribe in every run and resubscribe a new function which has the new value to compare.

any way that solution should be the right one because the unhandled subscrition in the prev solution